### PR TITLE
Publish sorbet-static plus Sorbet suite to Gemfury

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # sorbet-builder
-Builds the Sorbet Ruby gem for the linux/arm64 platform.
+Build the Sorbet Ruby gem for the linux/arm64 platform.
+
+## Usage
+There are a couple of ways to use this repository: the gems published to Gemfury, or directly building your own.
+
+### Gems on Gemfury
+This repository is used to build and publish gems to Gemfury.
+Just change your `Gemfile` like so:
+```
+source 'https://gem.fury.io/sorbet-multiarch/' do
+  gem 'sorbet-static'
+  gem 'sorbet'
+end
+```
+
+Specific versions can be used too (when published):
+```
+source 'https://gem.fury.io/sorbet-multiarch/' do
+  gem 'sorbet-static', '0.5.11150'
+  gem 'sorbet', '0.5.11150'
+end
+```
+
+### Build your own
+Clone this repository, run the scripts to build the gems you need, upload the gems to your artifact repository.
 
 ## Requirements
 1. An arm CPU (an Apple Silicon mac, other arm powered computer)
 1. Docker
 
-## Usage
-To build the latest version of Sorbet: `./build.sh`
+## Building sorbet-static
+To build the latest version of Sorbet static gem: `./build.sh`
 
 The result:
 ```
@@ -19,7 +43,7 @@ output
 ```
 
 ### Specific version
-To build a specific version of Sorbet: `SORBET_VERSION=0.5.10993 ./build.sh`
+To build a **specific version** of the Sorbet static gem: `SORBET_VERSION=0.5.10993 ./build.sh`
 
 The result:
 ```
@@ -30,3 +54,7 @@ output
 
 1 directory, 2 files
 ```
+
+## Disclaimer
+
+This project is not affiliated with either [Sorbet](https://github.com/sorbet/) or [Stripe](https://stripe.com/).

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Publishes the gems from ./output to Gemfury
+# Publishes the arm64 built gem from ./output to Gemfury, along with a
+# mirror of the other Sorbet gems.
 #
 # usage: GEMFURY_TOKEN=... ./publish.sh
 
@@ -8,7 +9,36 @@ set -eou pipefail
 
 GEMFURY_USERNAME=sorbet-multiarch
 
-for gem in output/*.gem; do
-  echo "Publishing $gem"
-  curl -F package=@$gem https://${GEMFURY_TOKEN}@push.fury.io/${GEMFURY_USERNAME}/
+function mirror_to_gemfury() {
+  GEM_FILENAME=$1
+
+  TMPDIR=$(mktemp -d)
+  OUTPUT_PATH="${TMPDIR}/1${GEM_FILENAME}"
+
+  echo "Mirroring $GEM_FILENAME"
+  curl \
+    --silent \
+    --output "$OUTPUT_PATH" \
+    https://rubygems.org/downloads/$GEM_FILENAME
+
+  curl -F package=@$OUTPUT_PATH https://${GEMFURY_TOKEN}@push.fury.io/${GEMFURY_USERNAME}/
+}
+
+for GEM in output/*.gem; do
+  VERSION=$(echo $GEM | sed -e 's/output\///' -e 's/sorbet-static-//' -e 's/-aarch64-linux.gem//')
+
+  echo "Mirroring Sorbet gems for ${VERSION} to Gemfury"
+
+  # Mirror the platform+architecture specific static gems
+  mirror_to_gemfury "sorbet-static-${VERSION}-x86_64-linux.gem"
+  mirror_to_gemfury "sorbet-static-${VERSION}-java.gem"
+  mirror_to_gemfury "sorbet-static-${VERSION}-universal-darwin.gem"
+
+  # Mirror remaining Sorbet gems
+  mirror_to_gemfury "sorbet-${VERSION}.gem"
+  mirror_to_gemfury "sorbet-runtime-${VERSION}.gem"
+  mirror_to_gemfury "sorbet-static-and-runtime-${VERSION}.gem"
+
+  echo "Publishing $GEM"
+  curl -F package=@$GEM https://${GEMFURY_TOKEN}@push.fury.io/${GEMFURY_USERNAME}/
 done

--- a/publish.sh
+++ b/publish.sh
@@ -13,7 +13,7 @@ function mirror_to_gemfury() {
   GEM_FILENAME=$1
 
   TMPDIR=$(mktemp -d)
-  OUTPUT_PATH="${TMPDIR}/1${GEM_FILENAME}"
+  OUTPUT_PATH="${TMPDIR}/${GEM_FILENAME}"
 
   echo "Mirroring $GEM_FILENAME"
   curl \


### PR DESCRIPTION
Publishes the arm64 build of Sorbet, along with a copy of the other Sorbet gems for that version to Gemfury. This makes it easy to use sorbet-multiarch in a `Gemfile`.